### PR TITLE
Enable graphite and add graphite template

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,12 +58,15 @@ reporting-disabled = false
 [[graphite]]
   bind-address = ":2003"
   database = "graphite"
-  enabled = false
+  enabled = true
   protocol = "tcp"
   batch-size = 1000
   batch-timeout = "1s"
   consistency-level = "one"
   separator = "."
+  templates = [
+    ".host.env.resource.measurement*"
+  ]
 
 [collectd]
   enabled = false

--- a/launch/influxdb-service.yml
+++ b/launch/influxdb-service.yml
@@ -24,3 +24,7 @@ expose:
   port: 88
   bind: 8088
   proto: tcp
+- name: graphite
+  port: 2003
+  bind: 2003
+  proto: tcp


### PR DESCRIPTION
Use the [Graphite plugin](https://github.com/influxdb/influxdb/tree/master/services/graphite) to parse tags from a measurement name.

The template(s) assume the measurement names are consistently formatted between 0.8 (in prod) and 0.9 (in staging).
