### PR TITLE
Use debian debian in Dockerfile (google/debian is deprecated) 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/debian:jessie
+FROM debian:jessie
 
 RUN apt-get update && apt-get install -y wget
 


### PR DESCRIPTION
The dockerhub repo we used to use for debian (`google/debian`) is deprecated and has not been updated for 2 years: https://hub.docker.com/r/google/debian/.

Though the page at that URL suggests moving to another Google debian,  we should just use the base debian, `debian`. We're already using it in many other repos, and it's less likely to change location in the future because it's maintained by debian vs google.